### PR TITLE
Address 5.1 deprecation warnings for active record callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ bundler_args: ""
 before_install: gem install bundler
 gemfile:
 - gemfiles/activerecord_4.2.gemfile
+- gemfiles/activerecord_5.0.gemfile
 - gemfiles/activerecord_5.1.gemfile
 - gemfiles/activerecord_5.2.gemfile
 script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ bundler_args: ""
 before_install: gem install bundler
 gemfile:
 - gemfiles/activerecord_4.2.gemfile
+- gemfiles/activerecord_5.1.gemfile
 - gemfiles/activerecord_5.2.gemfile
 script: bundle exec rake spec

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,17 @@ user.my_bits # => 3
  - builds update sql `User.set_bitfield_sql(insane: true, sensible: false) == 'my_bits = (my_bits | 6) - 4'`
  - **faster sql than any other bitfield lib** through combination of multiple bits into a single sql statement
  - gives access to bits `User.bitfields[:my_bits][:sensible] # => 4`
+ - **For ActiveRecord 5.1+:** [`ActiveRecord::AttributeMethods::Dirty`](https://api.rubyonrails.org/v5.1.7/classes/ActiveRecord/AttributeMethods/Dirty.html) and [`ActiveModel::Dirty`](https://api.rubyonrails.org/v5.1.7/classes/ActiveModel/Dirty.html) methods can be used on each bitfield:
+ ```ruby
+    user = User.new(seller: false)
+    user.seller = true
+    user.will_save_change_to_seller? # => true
+    user.seller_change_to_be_saved # => [false, true]
+
+    user.save
+    user.seller_before_last_save # => false
+    user.saved_change_to_seller # => [false, true]
+ ```
 
 Install
 =======

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,38 @@ describe User do
 end
 ````
 
+Introduced a shell script to `bundle install` and run specific versions of the spec suite for a given ActiveRecord version.
+
+````bash
+> sh specs_for_version.sh 5.1
+# Running rspec for ActiveRecord 5.1
+...
+````
+
+````bash
+> sh specs_for_version.sh 5.0 5.1 5.2
+# Running rspec for ActiveRecord 5.0
+...
+# Running rspec for ActiveRecord 5.1
+...
+# Running rspec for ActiveRecord 5.2
+...
+````
+
+Passing no arguments will result in running all ActiveRecord versions (as defined in the `/gemfiles` directory).
+
+````bash
+> sh specs_for_version.sh
+# Running rspec for ActiveRecord 4.2
+...
+# Running rspec for ActiveRecord 5.0
+...
+# Running rspec for ActiveRecord 5.1
+...
+# Running rspec for ActiveRecord 5.2
+...
+````
+
 TODO
 ====
  - convenient named scope `User.with_bitfields(xxx: true, yyy: false)`

--- a/gemfiles/activerecord_4.2.gemfile.lock
+++ b/gemfiles/activerecord_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.8.0)
+    bitfields (0.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.6" # internally required by AR
+
+gemspec :path=>"../"

--- a/gemfiles/activerecord_5.0.gemfile.lock
+++ b/gemfiles/activerecord_5.0.gemfile.lock
@@ -6,54 +6,54 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.3)
-      activesupport (= 5.2.3)
-    activerecord (5.2.3)
-      activemodel (= 5.2.3)
-      activesupport (= 5.2.3)
-      arel (>= 9.0)
-    activesupport (5.2.3)
+    activemodel (5.0.7.2)
+      activesupport (= 5.0.7.2)
+    activerecord (5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      arel (~> 7.0)
+    activesupport (5.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (9.0.0)
+    arel (7.1.4)
     bump (0.8.0)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
-    rake (12.3.2)
+    rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.3)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    sqlite3 (1.4.1)
+    rspec-support (3.8.2)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    wwtd (1.3.0)
+    wwtd (1.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.2.0)
+  activerecord (~> 5.0.0)
   bitfields!
   bump
   rake
   rspec (~> 3)
-  sqlite3
+  sqlite3 (~> 1.3.6)
   wwtd
 
 BUNDLED WITH

--- a/gemfiles/activerecord_5.1.gemfile
+++ b/gemfiles/activerecord_5.1.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
+gem "activerecord", "~> 5.1.0"
 
 gemspec :path=>"../"

--- a/gemfiles/activerecord_5.1.gemfile.lock
+++ b/gemfiles/activerecord_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.8.0)
+    bitfields (0.10.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/activerecord_5.1.gemfile.lock
+++ b/gemfiles/activerecord_5.1.gemfile.lock
@@ -1,23 +1,23 @@
 PATH
-  remote: .
+  remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.8.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.3)
-      activesupport (= 5.2.3)
-    activerecord (5.2.3)
-      activemodel (= 5.2.3)
-      activesupport (= 5.2.3)
-      arel (>= 9.0)
-    activesupport (5.2.3)
+    activemodel (5.1.7)
+      activesupport (= 5.1.7)
+    activerecord (5.1.7)
+      activemodel (= 5.1.7)
+      activesupport (= 5.1.7)
+      arel (~> 8.0)
+    activesupport (5.1.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (9.0.0)
+    arel (8.0.0)
     bump (0.8.0)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
@@ -48,7 +48,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.2.0)
+  activerecord (~> 5.1.0)
   bitfields!
   bump
   rake

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -254,7 +254,7 @@ describe Bitfields do
   end
 
   describe '#bitfield_changes' do
-    it "has no changes by defaut" do
+    it "has no changes by default" do
       User.new.bitfield_changes.should == {}
     end
 

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -218,30 +218,12 @@ describe Bitfields do
       user.bits.should == 7
     end
 
-    context "_was method" do
-      it "has _was" do
-        user = User.new
-        user.seller_was.should == false
-        user.seller = true
-        user.save!
-        user.seller_was.should == true
-      end
-
-      context "when called in a before_save" do
-        it "should not raise on deprecations" do
-          model = AvoidCallbackDeprecation.new
-          model.before_bit = true
-          model.save!
-        end
-      end
-
-      context "when called in an after_save" do
-        it "should not raise on deprecations" do
-          model = AvoidCallbackDeprecation.new
-          model.after_bit = true
-          model.save!
-        end
-      end
+    it "has _was" do
+      user = User.new
+      user.seller_was.should == false
+      user.seller = true
+      user.save!
+      user.seller_was.should == true
     end
 
     it "has _changed?" do
@@ -260,6 +242,75 @@ describe Bitfields do
       user.seller_change.should == [false, true]
       user.save!
       user.seller_change.should == nil
+    end
+
+    describe "ActiveRecord versions" do
+      if Bitfields.active_record_5_1_or_above?
+        it "has _before_last_save" do
+          user = User.new
+          user.seller_before_last_save.should == nil
+          user.seller = true
+          user.save!
+          user.seller_before_last_save.should == false
+        end
+
+        it "has _change_to_be_saved" do
+          user = User.new
+          user.seller_change_to_be_saved.should == nil
+          user.seller = true
+          user.seller_change_to_be_saved.should == [false, true]
+          user.save!
+          user.seller_change_to_be_saved.should == nil
+        end
+
+        it "has _in_database" do
+          user = User.new
+          user.seller_in_database.should == false
+          user.seller = true
+          user.save!
+          user.seller_in_database.should == true
+        end
+
+        it "has saved_change_to_" do
+          user = User.new
+          user.saved_change_to_seller.should == nil
+          user.seller = true
+          user.saved_change_to_seller.should == nil
+          user.save!
+          user.saved_change_to_seller.should == [false, true]
+        end
+
+        it "has saved_change_to_?" do
+          user = User.new
+          user.saved_change_to_seller?.should == false
+          user.seller = true
+          user.saved_change_to_seller?.should == false
+          user.save!
+          user.saved_change_to_seller?.should == true
+        end
+
+        it "has will_save_change_to_?" do
+          user = User.new
+          user.will_save_change_to_seller?.should == nil
+          user.seller = true
+          user.will_save_change_to_seller?.should == true
+          user.save!
+          user.will_save_change_to_seller?.should == nil
+          user.seller = false
+          user.will_save_change_to_seller?.should == true
+        end
+      else
+        it "does not have the newer methods" do
+          model = User.new
+
+          model.should_not respond_to(:seller_before_last_save)
+          model.should_not respond_to(:seller_change_to_be_saved)
+          model.should_not respond_to(:seller_in_database)
+          model.should_not respond_to(:saved_change_to_seller)
+          model.should_not respond_to(:saved_change_to_seller?)
+          model.should_not respond_to(:will_save_change_to_seller?)
+        end
+      end
     end
 
     it "has _became_true?" do
@@ -306,7 +357,7 @@ describe Bitfields do
 
     it "records a change when setting" do
       u = User.new(:seller => true)
-      u.changes.should == {'bits' => [0,1]}
+      u.changes.should include({ 'bits' => [0,1] })
       u.bitfield_changes.should == {'seller' => [false, true]}
     end
   end

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -240,7 +240,7 @@ describe Bitfields do
 
     context "when :added_instance_methods is false" do
       %i{
-        seller seller? seller= seller_was seller_changed? seller_change seller_became_true?
+        seller seller? seller= seller_was seller_changed? seller_change seller_became_true? seller_became_false?
       }.each do |meth|
         describe "method #{meth} is not generated" do
           UserWithInstanceOptions.new.respond_to?(meth).should == false

--- a/specs_for_version
+++ b/specs_for_version
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-BUNDLE_GEMFILE=gemfiles/activerecord_$1.gemfile bundle install && BUNDLE_GEMFILE=gemfiles/activerecord_$1.gemfile bundle exec rspec

--- a/specs_for_version
+++ b/specs_for_version
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+BUNDLE_GEMFILE=gemfiles/activerecord_$1.gemfile bundle install && BUNDLE_GEMFILE=gemfiles/activerecord_$1.gemfile bundle exec rspec

--- a/specs_for_version.sh
+++ b/specs_for_version.sh
@@ -6,7 +6,7 @@ function run_rspec () {
   echo "\n"
 
   BUNDLE_GEMFILE=gemfiles/activerecord_$activerecord_version.gemfile bundle install &&
-  BUNDLE_GEMFILE=gemfiles/activerecord_$activerecord_version.gemfile bundle exec rspec
+  BUNDLE_GEMFILE=gemfiles/activerecord_$activerecord_version.gemfile bundle exec rspec spec/
 }
 
 if [ $# -eq 0 ]

--- a/specs_for_version.sh
+++ b/specs_for_version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+function run_rspec () {
+  echo "Running rspec for ActiveRecord $activerecord_version"
+  printf '=%.0s' {1..100}
+  echo "\n"
+
+  BUNDLE_GEMFILE=gemfiles/activerecord_$activerecord_version.gemfile bundle install &&
+  BUNDLE_GEMFILE=gemfiles/activerecord_$activerecord_version.gemfile bundle exec rspec
+}
+
+if [ $# -eq 0 ]
+  then
+    for f in ./gemfiles/activerecord*.gemfile; do
+      activerecord_version=$(echo $f | egrep -o '[[:digit:]].[[:digit:]]' | head -n1)
+      run_rspec
+    done
+else
+  for activerecord_version; do
+    run_rspec
+  done
+fi


### PR DESCRIPTION
- For ActiveRecord 5.0 & below, the standaard active record dirty instance methods are still supported
- For ActiveRecord 5.1 & grated: [`ActiveRecord::AttributeMethods::Dirty`](https://api.rubyonrails.org/v5.1.7/classes/ActiveRecord/AttributeMethods/Dirty.html) and [`ActiveModel::Dirty`](https://api.rubyonrails.org/v5.1.7/classes/ActiveModel/Dirty.html) methods can be used on each bitfield:

 ```ruby
    user = User.new(seller: false)
    user.seller = true
    user.will_save_change_to_seller? # => true
    user.seller_change_to_be_saved # => [false, true]
    user.save
    user.seller_before_last_save # => false
    user.saved_change_to_seller # => [false, true]
 ```