### PR TITLE
Bitfields are loaded with the correct value when using `ActiveRecord.find`

### DIFF
--- a/gemfiles/activerecord_5.1.gemfile.lock
+++ b/gemfiles/activerecord_5.1.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.11.0)
+      activerecord (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.11.0)
+      activerecord (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -85,7 +85,7 @@ module Bitfields
           attribute bit_name, :boolean, default: false
 
           after_find do
-            send("#{bit_name}=", send(bit_name))
+            write_attribute(bit_name, send(bit_name))
             clear_attribute_changes([bit_name])
           end
 

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -84,6 +84,11 @@ module Bitfields
         if options[:added_instance_methods] != false
           attribute bit_name, :boolean, default: false
 
+          after_find do
+            send("#{bit_name}=", send(bit_name))
+            clear_attribute_changes([bit_name])
+          end
+
           define_method(bit_name) { bitfield_value(bit_name) }
           define_method("#{bit_name}?") { bitfield_value(bit_name) }
           define_method("#{bit_name}=") { |value| super(value); set_bitfield_value(bit_name, value) }

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -82,9 +82,11 @@ module Bitfields
     def add_bitfield_methods(column, options)
       if options[:added_instance_methods] != false
         after_find do
-          self.class.bitfields[column].keys.each do |bit_name|
-            write_attribute(bit_name, send(bit_name))
-            clear_attribute_changes([bit_name])
+          if self.has_attribute?(column)
+            self.class.bitfields[column].keys.each do |bit_name|
+              write_attribute(bit_name, send(bit_name))
+              clear_attribute_changes([bit_name])
+            end
           end
         end
       end

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -80,14 +80,18 @@ module Bitfields
     end
 
     def add_bitfield_methods(column, options)
-      bitfields[column].keys.each do |bit_name|
-        if options[:added_instance_methods] != false
-          attribute bit_name, :boolean, default: false
-
-          after_find do
+      if options[:added_instance_methods] != false
+        after_find do
+          self.class.bitfields[column].keys.each do |bit_name|
             write_attribute(bit_name, send(bit_name))
             clear_attribute_changes([bit_name])
           end
+        end
+      end
+
+      bitfields[column].keys.each do |bit_name|
+        if options[:added_instance_methods] != false
+          attribute bit_name, :boolean, default: false
 
           define_method(bit_name) { bitfield_value(bit_name) }
           define_method("#{bit_name}?") { bitfield_value(bit_name) }

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -84,7 +84,7 @@ module Bitfields
         after_find do
           if self.has_attribute?(column)
             self.class.bitfields[column].keys.each do |bit_name|
-              write_attribute(bit_name, send(bit_name))
+              write_attribute(bit_name, bitfield_value(bit_name))
               clear_attribute_changes([bit_name])
             end
           end

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -83,10 +83,9 @@ module Bitfields
       if options[:added_instance_methods] != false
         after_find do
           if self.has_attribute?(column)
-            self.class.bitfields[column].keys.each do |bit_name|
-              write_attribute(bit_name, bitfield_value(bit_name))
-              clear_attribute_changes([bit_name])
-            end
+            current_bitfields = bitfield_values(column)
+            current_bitfields.each(&method(:write_attribute))
+            clear_attribute_changes(current_bitfields.keys)
           end
         end
       end

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -190,94 +190,239 @@ describe Bitfields do
       user.bits.should == 7
     end
 
-    it "has _was" do
-      User.create!(:seller => true)
-      user = User.last
-      user.seller
-      user.seller = false
-      user.seller_was.should == true
-      user.save!
-      user.seller_was.should == false
+    context "when instantiating a new record" do
+      it "has _was" do
+        user = User.new(:seller => true)
+        user.seller_was.should == false
+        user.save!
+        user.seller_was.should == true
+      end
+
+      it "has _changed?" do
+        user = User.new(:seller => true)
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
+
+      it "has _change" do
+        user = User.new(:seller => true)
+        user.seller_change.should == [false, true]
+        user.save!
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+      end
+
+      it "has _before_last_save" do
+        user = User.new(:seller => true)
+        user.seller_before_last_save.should == nil
+        user.save!
+        user.seller_before_last_save.should == false
+      end
+
+      it "has _change_to_be_saved" do
+        user = User.new(:seller => true)
+        user.seller_change_to_be_saved.should == [false, true]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
+
+      it "has _in_database" do
+        user = User.new(:seller => true)
+        user.seller_in_database.should == false
+        user.save!
+        user.seller_in_database.should == true
+      end
+
+      it "has saved_change_to_" do
+        user = User.new(:seller => true)
+        user.saved_change_to_seller.should == nil
+        user.save!
+        user.saved_change_to_seller.should == [false, true]
+      end
+
+      it "has saved_change_to_?" do
+        user = User.new(:seller => true)
+        user.saved_change_to_seller?.should == false
+        user.save!
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        user = User.new(:seller => true)
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
-    it "has _changed?" do
-      User.create!(:seller => true)
-      user = User.last
-      user.seller_changed?.should == false
-      user.seller = false
-      user.seller_changed?.should == true
-      user.save!
-      user.seller_changed?.should == false
+    context "when creating a new model" do
+      it "has _was" do
+        user = User.create!(:seller => true)
+        user.seller = false
+        user.seller_was.should == true
+        user.save!
+        user.seller_was.should == false
+      end
+
+      it "has _changed?" do
+        user = User.create!(:seller => true)
+        user.seller_changed?.should == false
+        user.seller = false
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
+
+      it "has _change" do
+        user = User.create!(:seller => true)
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+        user.save!
+        user.seller_change.should == nil
+      end
+
+      it "has _before_last_save" do
+        user = User.create!(:seller => true)
+        user.seller_before_last_save.should == false
+        user.seller = false
+        user.save!
+        user.seller_before_last_save.should == true
+      end
+
+      it "has _change_to_be_saved" do
+        user = User.create!(:seller => true)
+        user.seller_change_to_be_saved.should == nil
+        user.seller = false
+        user.seller_change_to_be_saved.should == [true, false]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
+
+      it "has _in_database" do
+        user = User.create!(:seller => true)
+        user.seller_in_database.should == true
+        user.seller = false
+        user.save!
+        user.seller_in_database.should == false
+      end
+
+      it "has saved_change_to_" do
+        user = User.create!(:seller => true)
+        user.saved_change_to_seller.should == [false, true]
+      end
+
+      it "has saved_change_to_?" do
+        user = User.create!(:seller => true)
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        user = User.create!(:seller => true)
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = true
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
-    it "has _change" do
-      User.create!(:seller => true)
-      user = User.last
-      user.seller_change.should == nil
-      user.seller = false
-      user.seller_change.should == [true, false]
-      user.save!
-      user.seller_change.should == nil
-    end
+    context "when loading a model from the database" do
+      it "has _was" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller
+        user.seller = false
+        user.seller_was.should == true
+        user.save!
+        user.seller_was.should == false
+      end
 
-    it "has _before_last_save" do
-      User.create!(:seller => true)
-      user = User.last
-      user.seller_before_last_save.should == nil
-      user.seller = false
-      user.save!
-      user.seller_before_last_save.should == true
-    end
+      it "has _changed?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_changed?.should == false
+        user.seller = false
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
 
-    it "has _change_to_be_saved" do
-      User.create!(:seller => true)
-      user = User.last
-      user.seller_change_to_be_saved.should == nil
-      user.seller = false
-      user.seller_change_to_be_saved.should == [true, false]
-      user.save!
-      user.seller_change_to_be_saved.should == nil
-    end
+      it "has _change" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+        user.save!
+        user.seller_change.should == nil
+      end
 
-    it "has _in_database" do
-      User.create!(:seller => true)
-      user = User.last
-      user.seller_in_database.should == true
-      user.seller = false
-      user.save!
-      user.seller_in_database.should == false
-    end
+      it "has _before_last_save" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_before_last_save.should == nil
+        user.seller = false
+        user.save!
+        user.seller_before_last_save.should == true
+      end
 
-    it "has saved_change_to_" do
-      User.create!(:seller => true)
-      user = User.last
-      user.saved_change_to_seller.should == nil
-      user.seller = false
-      user.saved_change_to_seller.should == nil
-      user.save!
-      user.saved_change_to_seller.should == [true, false]
-    end
+      it "has _change_to_be_saved" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_change_to_be_saved.should == nil
+        user.seller = false
+        user.seller_change_to_be_saved.should == [true, false]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
 
-    it "has saved_change_to_?" do
-      User.create!(:seller => true)
-      user = User.last
-      user.saved_change_to_seller?.should == false
-      user.seller = false
-      user.saved_change_to_seller?.should == false
-      user.save!
-      user.saved_change_to_seller?.should == true
-    end
+      it "has _in_database" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_in_database.should == true
+        user.seller = false
+        user.save!
+        user.seller_in_database.should == false
+      end
 
-    it "has will_save_change_to_?" do
-      User.create!(:seller => true)
-      user = User.last
-      user.will_save_change_to_seller?.should == nil
-      user.seller = false
-      user.will_save_change_to_seller?.should == true
-      user.save!
-      user.will_save_change_to_seller?.should == nil
-      user.seller = true
-      user.will_save_change_to_seller?.should == true
+      it "has saved_change_to_" do
+        User.create!(:seller => true)
+        user = User.last
+        user.saved_change_to_seller.should == nil
+        user.seller = false
+        user.saved_change_to_seller.should == nil
+        user.save!
+        user.saved_change_to_seller.should == [true, false]
+      end
+
+      it "has saved_change_to_?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.saved_change_to_seller?.should == false
+        user.seller = false
+        user.saved_change_to_seller?.should == false
+        user.save!
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = true
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
     it "has _became_true?" do

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -423,6 +423,16 @@ describe Bitfields do
         user.seller = true
         user.will_save_change_to_seller?.should == true
       end
+
+      context "when the model loaded from the database does not select the bitfield column" do
+        it "does not try to assign the bitfield attributes" do
+          User.create!(:seller => true)
+
+          lambda{
+            User.select(:id).last
+          }.should_not raise_error
+        end
+      end
     end
 
     it "has _became_true?" do

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -455,6 +455,10 @@ describe Bitfields do
           UserWithInstanceOptions.new.respond_to?(meth).should == false
         end
       end
+
+      it "does not define an after_find method" do
+        UserWithInstanceOptions.new.respond_to?(:after_find).should == false
+      end
     end
 
     it "does still have the main bitfield method" do

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -191,82 +191,92 @@ describe Bitfields do
     end
 
     it "has _was" do
-      user = User.new
-      user.seller_was.should == false
-      user.seller = true
-      user.save!
+      User.create!(:seller => true)
+      user = User.last
+      user.seller
+      user.seller = false
       user.seller_was.should == true
+      user.save!
+      user.seller_was.should == false
     end
 
     it "has _changed?" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.seller_changed?.should == false
-      user.seller = true
+      user.seller = false
       user.seller_changed?.should == true
       user.save!
       user.seller_changed?.should == false
     end
 
     it "has _change" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.seller_change.should == nil
-      user.seller = true
-      user.seller_change.should == [false, true]
+      user.seller = false
+      user.seller_change.should == [true, false]
       user.save!
       user.seller_change.should == nil
     end
 
     it "has _before_last_save" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.seller_before_last_save.should == nil
-      user.seller = true
+      user.seller = false
       user.save!
-      user.seller_before_last_save.should == false
+      user.seller_before_last_save.should == true
     end
 
     it "has _change_to_be_saved" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.seller_change_to_be_saved.should == nil
-      user.seller = true
-      user.seller_change_to_be_saved.should == [false, true]
+      user.seller = false
+      user.seller_change_to_be_saved.should == [true, false]
       user.save!
       user.seller_change_to_be_saved.should == nil
     end
 
     it "has _in_database" do
-      user = User.new
-      user.seller_in_database.should == false
-      user.seller = true
-      user.save!
+      User.create!(:seller => true)
+      user = User.last
       user.seller_in_database.should == true
+      user.seller = false
+      user.save!
+      user.seller_in_database.should == false
     end
 
     it "has saved_change_to_" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.saved_change_to_seller.should == nil
-      user.seller = true
+      user.seller = false
       user.saved_change_to_seller.should == nil
       user.save!
-      user.saved_change_to_seller.should == [false, true]
+      user.saved_change_to_seller.should == [true, false]
     end
 
     it "has saved_change_to_?" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.saved_change_to_seller?.should == false
-      user.seller = true
+      user.seller = false
       user.saved_change_to_seller?.should == false
       user.save!
       user.saved_change_to_seller?.should == true
     end
 
     it "has will_save_change_to_?" do
-      user = User.new
+      User.create!(:seller => true)
+      user = User.last
       user.will_save_change_to_seller?.should == nil
-      user.seller = true
+      user.seller = false
       user.will_save_change_to_seller?.should == true
       user.save!
       user.will_save_change_to_seller?.should == nil
-      user.seller = false
+      user.seller = true
       user.will_save_change_to_seller?.should == true
     end
 


### PR DESCRIPTION
Ensure that models with bitfields set to true initialize with correct values
- Due to a quirk in how ActiveRecord initializes models when loading them from the database, the bitfields are set to `false` by default.
  - When new-ing up records from the db, ActiveRecord bypasses the standard initializer and instead uses an internal `instantiate` method 
    - https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/activerecord/lib/active_record/persistence.rb#L58-L72
- This doesn't affect the results of the getters and setters, since we manually define their behavior to inspect the bitfield column directly.
- What this does do, however, is "confuse" the underlying mutation tracker that keeps record of the models dirty attributes.
  - As such, when we set `foo = false` and check `.changes`, the bit column will show as changed, but `foo` will be missing.
  - If we then set `foo = true`, the bit column will be removed from `changes`, but `foo` now exists.
  - As such, when we set `foo = false` and check `.changes`, the bit column will show as changed, but `foo` will be missing.
  - If we then set `foo = true`, the bit column will be removed from `.changes`, but now `foo: [false, true]`.

Prefer using write_attribute over `send`ing
- Backfill specs for each lifecycle state of a model.

Update each bitfield set to define only a single after_find
- Creating this within the `added_instance_methods` block where the rest of the bit definitions happen would cause `after_find` to be defined for each individual bit.
- This change just avoids not only bloating the model, but eliminating unnecessary context switching for each method invocation.

Only try to load attributes if the bitfield column is included in the set of attributes
- When loading a model from the DB, we may not have loaded the bitfield column.
  - e.g. Loading a user model via `User.select(:id).first` would initialize a user without the `:bits` column.
  - As such, when our `after_find` runs, we would raise an error while attempting to load the value for `:bits`.
  - To resolve this, we only attempt to load the attribute if the model itself has the that attribute defined.

Prefer using internal method for grabbing value
- This was done since we may potentially have application code that may either overwrite the getter and produce unexpected behavior.
  - One such example would be mocking the getter for the bitfield which could cause issues for number of call expectations.


Refactor after_find logic to avoid unnecessary method calls
- Prefer using internal method to grab list of all current bitfield values.
- Only call `clear_attribute_changes` once for entire set of bitfields.