### PR TITLE
Replace virtual attributes with explicitly defined ActiveRecord dirty methods for bitfields

### DIFF
--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -80,23 +80,21 @@ module Bitfields
     end
 
     def add_bitfield_methods(column, options)
-      if options[:added_instance_methods] != false
-        after_find do
-          if self.has_attribute?(column)
-            current_bitfields = bitfield_values(column)
-            current_bitfields.each(&method(:write_attribute))
-            clear_attribute_changes(current_bitfields.keys)
-          end
-        end
-      end
-
       bitfields[column].keys.each do |bit_name|
         if options[:added_instance_methods] != false
-          attribute bit_name, :boolean, default: false
-
           define_method(bit_name) { bitfield_value(bit_name) }
           define_method("#{bit_name}?") { bitfield_value(bit_name) }
-          define_method("#{bit_name}=") { |value| super(value); set_bitfield_value(bit_name, value) }
+          define_method("#{bit_name}=") { |value| set_bitfield_value(bit_name, value) }
+
+          # Dirty methods usable in before_save contexts
+          define_method("#{bit_name}_was") { bitfield_value_was(bit_name) }
+          alias_method "#{bit_name}_in_database", "#{bit_name}_was"
+
+          define_method("#{bit_name}_change") { bitfield_value_change(bit_name) }
+          alias_method "#{bit_name}_change_to_be_saved", "#{bit_name}_change"
+
+          define_method("#{bit_name}_changed?") { bitfield_value_change(bit_name).present? }
+          alias_method "will_save_change_to_#{bit_name}?", "#{bit_name}_changed?"
 
           define_method("#{bit_name}_became_true?") do
             value = bitfield_value(bit_name)
@@ -106,6 +104,11 @@ module Bitfields
             value = bitfield_value(bit_name)
             !value && send("#{bit_name}_was") != value
           end
+
+          # Dirty methods usable in after_save contexts
+          define_method("#{bit_name}_before_last_save") { bitfield_value_before_last_save(bit_name) }
+          define_method("saved_change_to_#{bit_name}") { saved_change_to_bitfield_value(bit_name) }
+          define_method("saved_change_to_#{bit_name}?") { saved_change_to_bitfield_value(bit_name).present? }
         end
 
         if options[:scopes] != false
@@ -194,6 +197,25 @@ module Bitfields
     def bitfield_value_was(bit_name)
       column, bit, _ = bitfield_info(bit_name)
       send("#{column}_was") & bit != 0
+    end
+
+    def bitfield_value_before_last_save(bit_name)
+      column, bit, _ = bitfield_info(bit_name)
+      column_before_last_save = send("#{column}_before_last_save")
+      column_before_last_save.nil? ? nil : column_before_last_save & bit != 0
+    end
+
+    def bitfield_value_change(bit_name)
+      values = [bitfield_value_was(bit_name), bitfield_value(bit_name)]
+      values unless values[0] == values[1]
+    end
+
+    def saved_change_to_bitfield_value(bit_name)
+      value_before_last_save = bitfield_value_before_last_save(bit_name)
+      current_value = bitfield_value(bit_name)
+      unless value_before_last_save.nil? || (value_before_last_save == current_value)
+        [value_before_last_save, current_value]
+      end
     end
 
     def set_bitfield_value(bit_name, value)

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -253,7 +253,7 @@ describe Bitfields do
         user = User.new(:seller => true)
         user.will_save_change_to_seller?.should == true
         user.save!
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = false
         user.will_save_change_to_seller?.should == true
       end
@@ -323,11 +323,11 @@ describe Bitfields do
 
       it "has will_save_change_to_?" do
         user = User.create!(:seller => true)
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = false
         user.will_save_change_to_seller?.should == true
         user.save!
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = true
         user.will_save_change_to_seller?.should == true
       end
@@ -415,11 +415,11 @@ describe Bitfields do
       it "has will_save_change_to_?" do
         User.create!(:seller => true)
         user = User.last
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = false
         user.will_save_change_to_seller?.should == true
         user.save!
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = true
         user.will_save_change_to_seller?.should == true
       end
@@ -483,7 +483,7 @@ describe Bitfields do
 
     it "records a change when setting" do
       u = User.new(:seller => true)
-      u.changes.should == { 'bits' => [0,1], 'seller' => [false, true] }
+      u.changes.should == { 'bits' => [0,1] }
       u.bitfield_changes.should == {'seller' => [false, true]}
     end
   end


### PR DESCRIPTION
- Virtual attributes presented some challenges in regards to true values
  not correctly being loaded when loading from the database.
- Our previous solution, while retaining all Dirty methods provided by
  ActiveRecord, required us to manually add each bitfield's value to
  the change set.
  - This method in the worst case (64 explicit bits defined on a model)
    exhibited an almost 75x increase in loading time to load the model
    from the database.
- With this solution we do lose the ability to use the generic methods
  (e.g. `attribute_before_last_save?(:attribute)`), and the solution
  we could think of to resolve this would require ~~overriding `method_missing`~~.

This actually involves overriding the `ActiveRecord::Dirty` methods individually to intercept the attribute being passed and calling `send("#{interpolated_attirbute}_method")`. We experimented with this approach, but it turned out pretty.... Dirty... 👌, so we decided against going down that route.

Follow up to https://github.com/grosser/bitfields/pull/35